### PR TITLE
ci: add Docker build caching across workflow runs

### DIFF
--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -155,7 +155,7 @@ jobs:
             make --debug OS_TARGET=${OS_TARGET} dist python-dist dist-test
 
       - name: Build epmt-full-release
-        run: make --debug OS_TARGET=${OS_TARGET} epmt-full-release
+        run: make --debug OS_TARGET=${OS_TARGET} DOCKER_RUN_OPTS="${DOCKER_RUN_OPTS}" epmt-full-release
 
       # ── test-release image: layer-cached across runs via --cache-from ──
       # This image changes every commit (new EPMT artifacts baked in), so we


### PR DESCRIPTION
## Summary

Add Docker image caching to the `docker_build_test` workflow so that expensive, rarely-changing build steps are not rebuilt from scratch on every CI run.

## What changes

### 1. `epmt-build` image — full image cache (skip build entirely on hit)

This image is the build *environment* only (Rocky 8 + sqlite + Python 3.9 + pip deps). It does not contain EPMT code — the actual build runs in a container with a bind mount. The image only changes when the Dockerfile or `requirements.txt.py3` change.

- `docker save` / `docker load` + `actions/cache`, same pattern already used for the slurm-cluster image
- Cache key: `OS_TARGET + PYTHON_VERSION + SQLITE_VERSION + hash(Dockerfile, requirements.txt.py3)`
- On hit: load the tarball, re-tag if EPMT_VERSION bumped, skip the build entirely
- `make docker-dist` is split into explicit "build image" + "run container" steps so we control the `docker build` command

### 2. `test-release` image — layer-level cache via `--cache-from`

This image changes every commit (EPMT release tarball baked in), so the build cannot be skipped. But the first ~15 Dockerfile layers (yum, sqlite, Python, pip install ~130 packages) are identical across commits.

- Save the previous run's image via `docker save`, restore with `restore-keys` prefix matching
- Build with `--build-arg BUILDKIT_INLINE_CACHE=1` + `--cache-from` referencing the loaded image
- BuildKit reuses matching early layers and only rebuilds from the `COPY` of EPMT artifacts onward

### 3. Other cleanup

- `PYTHON_VERSION`, `SQLITE_VERSION`, `SQLITE_YEAR` added to workflow `env` (single source of truth, matching Makefile)
- `EPMT_VERSION` + derived variables extracted once in an early step (removes redundant `sed` extraction from two later steps)
- Scheduled (`cron`) runs bypass all caches to verify full builds still work

## Expected impact

On a typical push where the Dockerfile and requirements are unchanged:
- **`epmt-build` image:** ~0s (load from cache) instead of ~10-15 min (yum + compile Python + pip install)
- **`test-release` image:** only the final layers rebuild (~1-2 min) instead of ~10-15 min full rebuild

No changes to the Makefile, Dockerfiles, or test steps.