### PR TITLE
ci: add weekly workflow to prune stale Actions caches

### DIFF
--- a/.github/workflows/prune-actions-cache.yml
+++ b/.github/workflows/prune-actions-cache.yml
@@ -1,0 +1,30 @@
+name: Prune Actions Cache
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'   # every Sunday at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches unused for 7+ days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/actions/caches" \
+            --paginate \
+            --jq ".actions_caches[] | select(.last_accessed_at < \"${CUTOFF}\") | .id" \
+          | while read -r id; do
+              echo "Deleting cache ${id}"
+              gh api --method DELETE "/repos/${REPO}/actions/caches/${id}" --silent
+            done


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs weekly (Sundays at midnight UTC) and deletes any Actions caches that haven't been accessed in 7+ days.

## How it works

- Uses `gh api` to list all caches via the GitHub REST API
- Filters entries where `last_accessed_at` is older than 7 days (meaning both old **and** unused)
- Deletes each matching cache entry

## Why

GitHub auto-evicts caches not accessed in 7 days on a best-effort basis, but repos near the 10 GB limit benefit from explicit pruning. This ensures stale caches are cleaned up predictably.

## Details

- **Schedule:** `0 0 * * 0` (weekly, Sunday midnight UTC)
- **Manual trigger:** supported via `workflow_dispatch`
- **Permissions:** `actions: write` (minimum required to delete caches)
- **Pagination:** handled via `--paginate` for repos with many cache entries